### PR TITLE
Feat #14 브랜드를 클릭 횟수를 count하는 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 my_settings.py
 __pycache__/
+migrations/

--- a/brand/models.py
+++ b/brand/models.py
@@ -9,7 +9,7 @@ class Brand(models.Model):
     en_name = models.CharField(null=False, max_length=255, verbose_name='브랜드 영어 이름')
     site_url = models.CharField(null=True, max_length=255, verbose_name='브랜드 url')
     logo_url = models.CharField(null=True, max_length=255, verbose_name='로고 url')
-    total_click_count = models.BigIntegerField(default= 0, verbose_name='브랜드를 클릭한 횟수')
+    click_count = models.BigIntegerField(default= 0, verbose_name='브랜드를 클릭한 횟수')
     like_count = models.BigIntegerField(default= 0, verbose_name='브랜드를 좋아요한 횟수')
     created_at = models.DateTimeField(null = False, auto_now_add=True, verbose_name='생성된 날짜')
     updated_at = models.DateTimeField(null = True, auto_now=True, verbose_name='수정된 날짜')

--- a/brand/serializer.py
+++ b/brand/serializer.py
@@ -23,5 +23,7 @@ class mainBrandsSerializer(serializers.ModelSerializer):
         return queryset.select_related("brand_id")
 
 
-
-    
+class clickCountSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Brand
+        fields = ["id", "name", "click_count"]

--- a/brand/views.py
+++ b/brand/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 from rest_framework import status
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-from .serializer import BrandSerializer, mainBrandsSerializer
+from .serializer import BrandSerializer, mainBrandsSerializer, clickCountSerializer
 from .models import mainBrand, Brand
 import json
 
@@ -63,4 +63,12 @@ class markedBrandCountView(APIView):
 class BrandCountView(APIView):
     @swagger_auto_schema(tags=['브랜드 API'])
     def post(self, request, brandId):
-        return Response("브랜드를 클릭한 횟수를 카운팅합니다.", status = 200)
+        try:
+            queryset = Brand.objects.get(id = brandId)
+        except Exception as ex:
+            return JsonResponse({"status": 404, "message" : str(ex)}, status = 404, safe = False)
+        else:
+            queryset.click_count += 1
+            queryset.save()
+            serializer = clickCountSerializer(queryset)
+            return JsonResponse(serializer.data, status = 200, safe = False)

--- a/brand/views.py
+++ b/brand/views.py
@@ -61,7 +61,8 @@ class markedBrandCountView(APIView):
         return Response("브랜드를 북마크한 횟수를 카운팅합니다.", status = 200)
 
 class BrandCountView(APIView):
-    @swagger_auto_schema(tags=['브랜드 API'])
+    @swagger_auto_schema(tags=['브랜드 API'], responses = {200: clickCountSerializer})
+
     def post(self, request, brandId):
         try:
             queryset = Brand.objects.get(id = brandId)

--- a/config/settings.py
+++ b/config/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['52.79.90.204']
+ALLOWED_HOSTS = ['52.79.90.204', '127.0.0.1']
 
 
 # Application definition


### PR DESCRIPTION
# 주제

- 브랜드 클릭 횟수를 count하는 API를 제작한다.

# 작업 완료 내용 (자세히 작성)

- API를 호출할 때마다 brands.click_cout 가 증가하도록 한다.
- 존재하지 않는 브랜드를 호출했을 경우 에러코드와 메세지를 응답한다.

### response 예시

**POST /brand/count/:brandId**

- 정상 요청시
<pre><code>{
    "id": 1,
    "name": "아디다스",
    "click_count": 5
}</pre></code>

- 에러 발생시
<pre><code>{
    "status": 404,
    "message": "Brand matching query does not exist."
}</code></pre>

# 관련 이슈 번호

- #14 

# 미작업 내용

- 에러시 응답에 대해 swagger description을 아직 하지 않았다.

# 주의사항

- [ ]