### PR TITLE
Feat #23 API 전반적으로 리팩토링

### DIFF
--- a/brand/serializer.py
+++ b/brand/serializer.py
@@ -12,9 +12,19 @@ class BrandSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'en_name', 'site_url', 'logo_url', 'click_count', 'like_count']
 
 class mainBranditemSerializer(serializers.ModelSerializer):
+    is_liked = serializers.SerializerMethodField()
+
+    def get_is_liked(self, obj):
+        try:
+            Is_liked = likedBrand.objects.get(user = self.context.get("user_id"), brand = obj.id)
+        except likedBrand.DoesNotExist:
+            Is_liked = False
+        else:
+            Is_liked = True
+        return Is_liked
     class Meta:
         model = Brand
-        fields = ['id', 'name', 'en_name', 'site_url', 'logo_url', 'Img_url']
+        fields = ['id', 'name', 'en_name', 'site_url', 'logo_url', 'Img_url', 'is_liked']
 
 class BrandIdNameSerializer(serializers.ModelSerializer):
     class Meta:
@@ -33,10 +43,14 @@ class MainBrandType:
 
 class brandJoinSerializer(serializers.ModelSerializer):
     brand = mainBranditemSerializer(read_only = True)
+    is_liked = serializers.SerializerMethodField()
 
+    def get_is_liked(self, obj):
+        return None
     class Meta:
         model = mainBrand
-        fields = ["brand"]
+        fields = ["brand", 'is_liked']
+
 
 #### clickCount 관련 serializers ####
 

--- a/brand/serializer.py
+++ b/brand/serializer.py
@@ -9,7 +9,7 @@ from .models import mainBrand, Brand, likedBrand
 class BrandSerializer(serializers.ModelSerializer):
     class Meta:
         model = Brand
-        fields = ['id', 'name', 'en_name', 'site_url', 'logo_url']
+        fields = ['id', 'name', 'en_name', 'site_url', 'logo_url', 'click_count', 'like_count']
 
 class mainBranditemSerializer(serializers.ModelSerializer):
     class Meta:
@@ -23,47 +23,18 @@ class BrandIdNameSerializer(serializers.ModelSerializer):
 
 #### main브랜드 관련 serializers ####
 
-# mainBrand 응답을 커스텀하기 위한 class
-class mainBrandType(object):
-    def __init__(self, list):
-        self.list = list
-
 # brands 테이블과 leftjoin된 brand_id 필드의 정보만 불러온다.
 class brandJoinSerializer(serializers.ModelSerializer):
     brand = mainBranditemSerializer(read_only = True)
+    Is_liked = serializers.SerializerMethodField()
+
+    def get_Is_liked (self, obj, data):
+        likedBrand.objects.get(userId = data, )
+        return 
 
     class Meta:
         model = mainBrand
         fields = ["brand"]
-
-# join된 정보에는 모두 brand_id column이 맨 앞에 붙어 있기에 제거해준다.
-class mainBrandSerializer(serializers.Serializer):
-    brandList = serializers.SerializerMethodField()
-
-    def get_brandList(self, obj):
-        data = list(map(lambda x : x['brand'], obj.list))
-        return data
-
-class swaggermainBrand(serializers.Serializer):
-    brandList = mainBranditemSerializer(many = True)
-    
-
-#### popular 브랜드 관련 serializers ####
-
-# popularBrand 응답을 커스텀하기 위한 class
-class popularBrandType(object):
-    def __init__(self, size, list):
-        self.size = size
-        self.sortBy = 'popular'
-        self.brandList = list
-
-# popularBrand를 객체로 받아 serialize 해준다.
-class popularBrandSerializer(serializers.Serializer):
-    size = serializers.IntegerField()
-    sortBy = serializers.CharField()
-    brandList = BrandSerializer(many = True)
-
-
 
 #### clickCount 관련 serializers ####
 

--- a/brand/serializer.py
+++ b/brand/serializer.py
@@ -24,13 +24,15 @@ class BrandIdNameSerializer(serializers.ModelSerializer):
 #### main브랜드 관련 serializers ####
 
 # brands 테이블과 leftjoin된 brand_id 필드의 정보만 불러온다.
+
+class MainBrandType:
+    def __init__(self, brand, user):
+        self.brand = brand
+        self.user = user
+
+
 class brandJoinSerializer(serializers.ModelSerializer):
     brand = mainBranditemSerializer(read_only = True)
-    Is_liked = serializers.SerializerMethodField()
-
-    def get_Is_liked (self, obj, data):
-        likedBrand.objects.get(userId = data, )
-        return 
 
     class Meta:
         model = mainBrand

--- a/brand/urls.py
+++ b/brand/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path 
 from django.conf import settings 
-from .views import brandView, brandAddView, brandMainView,brandPopularView,brandSearchView, BrandCountView, markedBrandCountView, markedBrandSearchView, markedBrandView
+from .views import brandView, brandAddView, brandMainView,brandPopularView,brandSearchView, markedBrandCountView, markedBrandSearchView, markedBrandView
 
 urlpatterns = [ 
     path("brand/<int:brandId>", brandView.as_view(), name = "getBrand"),
@@ -8,8 +8,7 @@ urlpatterns = [
     path("brands/popular", brandPopularView.as_view(), name = "GetpopularBrands"),
     path("brands/main", brandMainView.as_view(), name = "GetmainBrands"),
     path("brands/search", brandSearchView.as_view({'get': 'list'}), name = "GetmainBrands"),
-    path("brands/marked", markedBrandView.as_view(), name = "GetmainBrands"),
-    path("brands/marked/<search>", markedBrandSearchView.as_view(), name = "GetmainBrands"),
-    path("brand/mark", markedBrandCountView.as_view(), name = "GetmainBrands"),
-    path("brand/count/<int:brandId>", BrandCountView.as_view(), name = "GetmainBrands"),
+    path("brands/liked", markedBrandView.as_view(), name = "GetmainBrands"),
+    path("brands/liked/<search>", markedBrandSearchView.as_view(), name = "GetmainBrands"),
+    path("brand/like", markedBrandCountView.as_view(), name = "GetmainBrands"),
 ]

--- a/brand/views.py
+++ b/brand/views.py
@@ -1,3 +1,4 @@
+from django.core import serializers
 from django.http.response import JsonResponse
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -32,14 +33,7 @@ response_schema_dict = {
     
 }
 
-def Is_liked(request, brandId):
-    try:
-        Is_liked = likedBrand.objects.get(user = request.data["user"], brand = brandId)
-    except likedBrand.DoesNotExist:
-        Is_liked = False
-    else:
-        Is_liked = True
-    return Is_liked
+
 
 
 class brandView(APIView):
@@ -84,11 +78,8 @@ class brandMainView(APIView):
     def get(self, request):
         query = mainBrand.objects.filter(Is_deleted = False)
         query = query.select_related("brand")
-        serializer = brandJoinSerializer(query, many = True)
-        data = []
-        for x in serializer.data:
-            x['brand'].setdefault('Is_liked', Is_liked(request, x['brand']['id']))
-            data.append(x['brand'])
+        serializer = brandJoinSerializer(query, many = True, context={'user_id': request.data['user']})
+        data = list(map(lambda x : x['brand'], serializer.data))
         return JsonResponse(data, status = 200, safe = False)
 
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -19,10 +19,10 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path("api/", include(("product.urls", "product"))),
-    path("api/", include(("brand.urls", "brand"))),
-    path("api/", include(("folder.urls", "folder"))),
-    path("api/", include(("user.urls", "user"))),
+    path("", include(("product.urls", "product"))),
+    path("", include(("brand.urls", "brand"))),
+    path("", include(("folder.urls", "folder"))),
+    path("", include(("user.urls", "user"))),
 ]
 
 


### PR DESCRIPTION
# 주제

- API response 형태 등을 프론트의 요구에 맞추어 수정합니다.

# 작업 완료 내용 (자세히 작성)

1. 배열을 넘겨줄 때는 key 없이 딱 배열만 넘겨주기 
2. main페이지의 정보 넘겨줄 때 Is_liked 정보도 넘겨주기 
3. 브랜드 카운트하는 API와 상세정보 내려주는 API를 통합 
4. 인기순 브랜드 보여줄 때는 size 그냥 10으로 고정해서 내려주기 
5. Search 부분 swagger 파라미터 변경하기(search -> name으로) 
6. Mark, marked 로 된 uri는 like로 바꾸기 
7. 좋아요 했을 경우 결과는 succes 또는 fail 정도로만 보내주기 

# 관련 이슈 번호

- #23 

# 미작업 내용

- swagger response 예시 추가

# 주의사항

- [ ]